### PR TITLE
Fix for W3 Total Cache integration

### DIFF
--- a/views/page.twig
+++ b/views/page.twig
@@ -4,10 +4,13 @@
 	<main class="content-wrapper">
 		<article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
       {# thumbnail #}
-      <div class="post-thumbnail">
-        <div class="post-thumbnail-bg-layer" style="background-image: url('{{ post.thumbnail.src|resize(1200, 300, "center") }}')"></div>
-        <img class="post-thumbnail-image" src="{{ post.thumbnail.src|resize(1200, 300, "center") }}"/>
-      </div>
+      {% if post.thumbnail %}
+        <div class="post-thumbnail">
+          <div class="post-thumbnail-bg-layer" style="background-image: url('{{ post.thumbnail.src|resize(1200, 300, "center") }}')"></div>
+          <img class="post-thumbnail-image" src="{{ post.thumbnail.src|resize(1200, 300, "center") }}"/>
+        </div>
+      {% endif %}
+
       {# title #}
       <h1 class="post-title">{{ post.title|striptags|raw }}</h1>
 

--- a/views/single.twig
+++ b/views/single.twig
@@ -4,11 +4,14 @@
 	<main class="content-wrapper">
 		<article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
       {# thumbnail #}
-      <div class="post-thumbnail">
-        {% set thumbnail_src = post.meta('_banner_image_desktop') ? Image(post.meta('_banner_image_desktop')).src('in_post_thumbnail') : post.thumbnail.src("in_post_thumbnail") %}
-        <div class="post-thumbnail-bg-layer" style="background-image: url('{{ thumbnail_src }}')"></div>
-        <img class="post-thumbnail-image" src="{{ thumbnail_src }}"></img>
-      </div>
+      {% set thumbnail_src = post.meta('_banner_image_desktop') ? Image(post.meta('_banner_image_desktop')).src('in_post_thumbnail') : post.thumbnail.src("in_post_thumbnail") %}
+      {% if thumbnail_src %}
+        <div class="post-thumbnail">
+          <div class="post-thumbnail-bg-layer" style="background-image: url('{{ thumbnail_src }}')"></div>
+          <img class="post-thumbnail-image" src="{{ thumbnail_src }}"></img>
+        </div>
+      {% endif %}
+
       {# title #}
       <h1 class="post-title">{{ post.title|striptags|raw }}</h1>
 


### PR DESCRIPTION
修复: 当开启W3 Total Cache插件并post thumbnail不存在的情况下post thumbnail位置出现空白占位的情况

![image](https://user-images.githubusercontent.com/871037/77134685-7a43c600-6a3e-11ea-8a00-966040d3ac01.png)
